### PR TITLE
Fix react-android not found error on android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -256,12 +256,8 @@ android {
 def kotlin_version = safeExtGet('kotlinVersion', project.properties['RNGH_kotlinVersion'])
 
 dependencies {
-    //noinspection GradleDynamicVersion
-    if (REACT_NATIVE_MINOR_VERSION >= 71) {
-        implementation "com.facebook.react:react-android" // version substituted by RNGP
-    } else {
-        implementation 'com.facebook.react:react-native:+' // from node_modules
-    }
+    implementation 'com.facebook.react:react-native:+' // from node_modules
+    
 
     if (shouldUseCommonInterfaceFromReanimated()) {
         // Include Reanimated as dependency to load the common interface


### PR DESCRIPTION
I have a Project on `"react-native": "0.72.3"`. When building for android I get the following error:

```
Could not determine the dependencies of task ':react-native-gesture-handler:compileDebugAidl'.
> Could not resolve all task dependencies for configuration ':react-native-gesture-handler:debugCompileClasspath'.
   > Could not find com.facebook.react:react-android:.
     Required by:
         project :react-native-gesture-handler 
```

With my change it works. 

I did not investigate this far, but as I understand from [this comment](https://github.com/callstack/react-native-builder-bob/issues/353#issuecomment-1443427643) the dependency will automatically be corrected in the respective react-native versions (?)